### PR TITLE
chore: Migrate to Spring Boot 4.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'jacoco'
 	id 'idea'
 	id 'eclipse'
-	id 'org.springframework.boot' version '4.0.0'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'com.gorylenko.gradle-git-properties' version '2.5.4'
 	id 'com.github.ben-manes.versions' version '0.53.0'
@@ -68,6 +68,9 @@ repositories {
 }
 
 dependencies {
+	// Explicitly use Jackson 3.x BOM for Spring Boot 4.x compatibility
+	implementation(platform('tools.jackson:jackson-bom:3.0.3'))
+
 	implementation('org.springframework.boot:spring-boot-starter-actuator')
 	implementation('org.springframework.boot:spring-boot-starter-data-cassandra-reactive')
 	implementation('org.springframework.boot:spring-boot-starter-webflux')


### PR DESCRIPTION
## Summary

This PR updates Spring Boot from 4.0.0 to 4.0.1 and adds explicit Jackson 3.x BOM to ensure consistent dependency management across all modules.

## Changes

### Build Configuration
- **Spring Boot plugin:** 4.0.0 → 4.0.1
- **Jackson BOM:** Added explicit `tools.jackson:jackson-bom:3.0.3`

### Why These Changes?

Spring Boot 4.x uses Jackson 3.x with the new `tools.jackson` groupId. Adding an explicit BOM prevents transitive dependency conflicts between old (`com.fasterxml.jackson`) and new (`tools.jackson`) Jackson artifacts.

## Code Changes

✅ **No code changes required!**

This project doesn't use Jackson directly in source code - Spring Boot handles JSON serialization transparently through the starter dependencies.

## Validation

- ✅ Clean build successful
- ✅ Compilation passed (all source files)
- ✅ Dependencies verified: Jackson 3.0.3 (tools.jackson.core)
- ⚠️ Integration tests skipped (require Cassandra container)

## Test Plan

- [ ] Run full build: `./gradlew clean build`
- [ ] Run with Cassandra: `docker-compose up -d && ./gradlew test`
- [ ] Verify application startup: `./gradlew bootRun`
- [ ] Test JSON serialization/deserialization
- [ ] Validate Cassandra reactive queries

## Notes

**Migration Tier:** Low Risk (Tier 1)
- No source code changes
- Only version bumps in build configuration
- Build and compilation successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)